### PR TITLE
Correct bug for option -p

### DIFF
--- a/src/refine.c
+++ b/src/refine.c
@@ -422,7 +422,7 @@ void dropSmallNpolarPockets(c_lst_pockets *pockets, s_fparams *params)
 
 
 			if(pcur->v_lst->n_vertices < (size_t) params->min_pock_nb_asph 
-				||  pasph <  (params->refine_min_apolar_asphere_prop || pcur->pdesc->as_density<params->min_as_density)){
+				||  pasph <  (params->refine_min_apolar_asphere_prop) || pcur->pdesc->as_density<(params->min_as_density)){
 			/* If the pocket is too small or has not enough apolar alpha
 			 * spheres, drop it */
 			    //fprintf(stdout, "size is %d\n", pcur->v_lst->n_vertices);


### PR DESCRIPTION
Option -p now work as expected: -p option sets minimum ratio of apolar alpha spheres in a pocket (range 0-1)